### PR TITLE
router.query is empty, use router.asPath instead

### DIFF
--- a/pages/order-confirmation.tsx
+++ b/pages/order-confirmation.tsx
@@ -9,7 +9,8 @@ const UsagePage = (): JSX.Element => {
   const title = 'Подтверждение заказа';
 
   useEffect(() => {
-    const { m } = router.query;
+    const urlSearchParams = new URLSearchParams(router.asPath.split('?').pop());
+    const m = urlSearchParams.get('m');
     const orderIdValue = parseInt(m as string, 10);
 
     if (!(orderIdValue > 0)) {


### PR DESCRIPTION
To get orderId value router.query was used, but it could be empty during initialization and redirect happens before. We won't have such problems with the use of URLSearchParams